### PR TITLE
larger pointer type

### DIFF
--- a/pyopencl_blas/blas.pyx
+++ b/pyopencl_blas/blas.pyx
@@ -7,7 +7,9 @@ from pyopencl.array import Array
 
 
 dtype_size = {np.dtype('float32'): 4,
-              np.dtype('float64'): 8}
+              np.dtype('float64'): 8,
+              np.dtype('complex64'): 8,
+              np.dtype('complex128'): 16}
 
 
 def dtypes_str(dtypes):
@@ -93,11 +95,37 @@ cdef extern from "clBLAS.h":
         cl_uint numEventsInWaitList,
         const cl_event *eventWaitList,
         cl_event *events)
+    clblasStatus clblasCswap(
+        size_t N,
+        cl_mem X,
+        size_t offx,
+        int incx,
+        cl_mem Y,
+        size_t offy,
+        int incy,
+        cl_uint numCommandQueues,
+        cl_command_queue *commandQueues,
+        cl_uint numEventsInWaitList,
+        const cl_event *eventWaitList,
+        cl_event *events)
+    clblasStatus clblasZswap(
+        size_t N,
+        cl_mem X,
+        size_t offx,
+        int incx,
+        cl_mem Y,
+        size_t offy,
+        int incy,
+        cl_uint numCommandQueues,
+        cl_command_queue *commandQueues,
+        cl_uint numEventsInWaitList,
+        const cl_event *eventWaitList,
+        cl_event *events)
 
 
 def swap(queue, x, y):
     """y, x = x, y"""
-    dtype = check_dtype([x, y], ['float32', 'float64'])
+    dtype = check_dtype([x, y], ['float32', 'float64', 'complex64', 'complex128'])
     check_vector(x, 'x')
     check_vector(y, 'y')
 
@@ -126,6 +154,16 @@ def swap(queue, x, y):
             numEventsInWaitList, eventWaitList, &event)
     elif dtype == np.dtype('float64'):
         err = clblasDswap(
+            N, xdata, offx, incx, ydata, offy, incy,
+            numCommandQueues, &commandQueue,
+            numEventsInWaitList, eventWaitList, &event)
+    elif dtype == np.dtype('complex64'):
+        err = clblasCswap(
+            N, xdata, offx, incx, ydata, offy, incy,
+            numCommandQueues, &commandQueue,
+            numEventsInWaitList, eventWaitList, &event)
+    elif dtype == np.dtype('complex128'):
+        err = clblasZswap(
             N, xdata, offx, incx, ydata, offy, incy,
             numCommandQueues, &commandQueue,
             numEventsInWaitList, eventWaitList, &event)
@@ -160,11 +198,33 @@ cdef extern from "clBLAS.h":
         cl_uint numEventsInWaitList,
         const cl_event *eventWaitList,
         cl_event *events)
+    clblasStatus clblasCscal(
+        size_t N,
+        cl_float2 alpha,
+        cl_mem X,
+        size_t offx,
+        int incx,
+        cl_uint numCommandQueues,
+        cl_command_queue *commandQueues,
+        cl_uint numEventsInWaitList,
+        const cl_event *eventWaitList,
+        cl_event *events)
+    clblasStatus clblasZscal(
+        size_t N,
+        cl_double2 alpha,
+        cl_mem X,
+        size_t offx,
+        int incx,
+        cl_uint numCommandQueues,
+        cl_command_queue *commandQueues,
+        cl_uint numEventsInWaitList,
+        const cl_event *eventWaitList,
+        cl_event *events)
 
 
 def scal(queue, alpha, x):
     """x <- alpha * x"""
-    dtype = check_dtype([x], ['float32', 'float64'])
+    dtype = check_dtype([x], ['float32', 'float64', 'complex64', 'complex128'])
     check_vector(x, 'x')
 
     cdef size_t N = x.shape[0]
@@ -189,6 +249,16 @@ def scal(queue, alpha, x):
     elif dtype == np.dtype('float64'):
         err = clblasDscal(
             N, <cl_double>alpha, xdata, offx, incx,
+            numCommandQueues, &commandQueue,
+            numEventsInWaitList, eventWaitList, &event)
+    elif dtype == np.dtype('complex64'):
+        err = clblasCscal(
+            N, <cl_float2>cl_float2(x=alpha.real,y=alpha.imag), xdata, offx, incx,
+            numCommandQueues, &commandQueue,
+            numEventsInWaitList, eventWaitList, &event)
+    elif dtype == np.dtype('complex128'):
+        err = clblasZscal(
+            N, <cl_double2>cl_double2(x=alpha.real,y=alpha.imag), xdata, offx, incx,
             numCommandQueues, &commandQueue,
             numEventsInWaitList, eventWaitList, &event)
     else:
@@ -226,11 +296,37 @@ cdef extern from "clBLAS.h":
         cl_uint numEventsInWaitList,
         const cl_event *eventWaitList,
         cl_event *events)
+    clblasStatus clblasCcopy(
+        size_t N,
+        cl_mem X,
+        size_t offx,
+        int incx,
+        cl_mem Y,
+        size_t offy,
+        int incy,
+        cl_uint numCommandQueues,
+        cl_command_queue *commandQueues,
+        cl_uint numEventsInWaitList,
+        const cl_event *eventWaitList,
+        cl_event *events)
+    clblasStatus clblasZcopy(
+        size_t N,
+        cl_mem X,
+        size_t offx,
+        int incx,
+        cl_mem Y,
+        size_t offy,
+        int incy,
+        cl_uint numCommandQueues,
+        cl_command_queue *commandQueues,
+        cl_uint numEventsInWaitList,
+        const cl_event *eventWaitList,
+        cl_event *events)
 
 
 def copy(queue, x, y):
     """y, x = x, y"""
-    dtype = check_dtype([x, y], ['float32', 'float64'])
+    dtype = check_dtype([x, y], ['float32', 'float64', 'complex64', 'complex128'])
     check_vector(x, 'x')
     check_vector(y, 'y')
 
@@ -259,6 +355,16 @@ def copy(queue, x, y):
             numEventsInWaitList, eventWaitList, &event)
     elif dtype == np.dtype('float64'):
         err = clblasDcopy(
+            N, xdata, offx, incx, ydata, offy, incy,
+            numCommandQueues, &commandQueue,
+            numEventsInWaitList, eventWaitList, &event)
+    elif dtype == np.dtype('complex64'):
+        err = clblasCcopy(
+            N, xdata, offx, incx, ydata, offy, incy,
+            numCommandQueues, &commandQueue,
+            numEventsInWaitList, eventWaitList, &event)
+    elif dtype == np.dtype('complex128'):
+        err = clblasZcopy(
             N, xdata, offx, incx, ydata, offy, incy,
             numCommandQueues, &commandQueue,
             numEventsInWaitList, eventWaitList, &event)
@@ -299,11 +405,39 @@ cdef extern from "clBLAS.h":
         cl_uint numEventsInWaitList,
         const cl_event *eventWaitList,
         cl_event *events)
+    clblasStatus clblasCaxpy(
+        size_t N,
+        cl_float2 alpha,
+        cl_mem X,
+        size_t offx,
+        int incx,
+        cl_mem Y,
+        size_t offy,
+        int incy,
+        cl_uint numCommandQueues,
+        cl_command_queue *commandQueues,
+        cl_uint numEventsInWaitList,
+        const cl_event *eventWaitList,
+        cl_event *events)
+    clblasStatus clblasZaxpy(
+        size_t N,
+        cl_double2 alpha,
+        cl_mem X,
+        size_t offx,
+        int incx,
+        cl_mem Y,
+        size_t offy,
+        int incy,
+        cl_uint numCommandQueues,
+        cl_command_queue *commandQueues,
+        cl_uint numEventsInWaitList,
+        const cl_event *eventWaitList,
+        cl_event *events)
 
 
 def axpy(queue, x, y, alpha=1.0):
     """y <- alpha * x + y"""
-    dtype = check_dtype([x, y], ['float32', 'float64'])
+    dtype = check_dtype([x, y], ['float32', 'float64', 'complex64', 'complex128'])
     check_vector(x, 'x')
     check_vector(y, 'y')
 
@@ -333,6 +467,16 @@ def axpy(queue, x, y, alpha=1.0):
     elif dtype == np.dtype('float64'):
         err = clblasDaxpy(
             N, <cl_double>alpha, xdata, offx, incx, ydata, offy, incy,
+            numCommandQueues, &commandQueue,
+            numEventsInWaitList, eventWaitList, &event)
+    elif dtype == np.dtype('complex64'):
+        err = clblasCaxpy(
+            N, <cl_float2>cl_float2(x=alpha.real,y=alpha.imag), xdata, offx, incx, ydata, offy, incy,
+            numCommandQueues, &commandQueue,
+            numEventsInWaitList, eventWaitList, &event)
+    elif dtype == np.dtype('complex128'):
+        err = clblasZaxpy(
+            N, <cl_double2>cl_double2(x=alpha.real,y=alpha.imag), xdata, offx, incx, ydata, offy, incy,
             numCommandQueues, &commandQueue,
             numEventsInWaitList, eventWaitList, &event)
     else:
@@ -598,11 +742,53 @@ cdef extern from "clBLAS.h":
         cl_uint numEventsInWaitList,
         const cl_event *eventWaitList,
         cl_event *events)
+    clblasStatus clblasCgemv(
+        clblasOrder order,
+        clblasTranspose transA,
+        size_t M,
+        size_t N,
+        cl_float2 alpha,
+        const cl_mem A,
+        size_t offA,
+        size_t lda,
+        const cl_mem x,
+        size_t offx,
+        int incx,
+        cl_float2 beta,
+        cl_mem y,
+        size_t offy,
+        int incy,
+        cl_uint numCommandQueues,
+        cl_command_queue *commandQueues,
+        cl_uint numEventsInWaitList,
+        const cl_event *eventWaitList,
+        cl_event *events)
+    clblasStatus clblasZgemv(
+        clblasOrder order,
+        clblasTranspose transA,
+        size_t M,
+        size_t N,
+        cl_double2 alpha,
+        const cl_mem A,
+        size_t offA,
+        size_t lda,
+        const cl_mem x,
+        size_t offx,
+        int incx,
+        cl_double2 beta,
+        cl_mem y,
+        size_t offy,
+        int incy,
+        cl_uint numCommandQueues,
+        cl_command_queue *commandQueues,
+        cl_uint numEventsInWaitList,
+        const cl_event *eventWaitList,
+        cl_event *events)
 
 
 def gemv(queue, A, x, y, bool transA=False, alpha=1.0, beta=0.0):
     """y <- alpha * dot(A, x) + beta * y"""
-    dtype = check_dtype([A, x, y], ['float32', 'float64'])
+    dtype = check_dtype([A, x, y], ['float32', 'float64', 'complex64', 'complex128'])
     check_matrix(A, 'A')
     check_vector(x, 'x')
     check_vector(y, 'y')
@@ -642,6 +828,20 @@ def gemv(queue, A, x, y, bool transA=False, alpha=1.0, beta=0.0):
             clblasRowMajor, clblasTrans if transA else clblasNoTrans,
             M, N, <cl_double>alpha, Adata, offA, lda,
             xdata, offx, incx, <cl_double>beta, ydata, offy, incy,
+            numCommandQueues, &commandQueue,
+            numEventsInWaitList, eventWaitList, &event)
+    elif dtype == np.dtype('complex64'):
+        err = clblasCgemv(
+            clblasRowMajor, clblasTrans if transA else clblasNoTrans,
+            M, N, <cl_float2>cl_float2(x=alpha.real,y=alpha.imag), Adata, offA, lda,
+            xdata, offx, incx, <cl_float2>cl_float2(x=beta,y=0.0), ydata, offy, incy,
+            numCommandQueues, &commandQueue,
+            numEventsInWaitList, eventWaitList, &event)
+    elif dtype == np.dtype('complex128'):
+        err = clblasZgemv(
+            clblasRowMajor, clblasTrans if transA else clblasNoTrans,
+            M, N, <cl_double2>cl_double2(x=alpha.real,y=alpha.imag), Adata, offA, lda,
+            xdata, offx, incx, <cl_double2>cl_double2(x=beta,y=0.0), ydata, offy, incy,
             numCommandQueues, &commandQueue,
             numEventsInWaitList, eventWaitList, &event)
     else:
@@ -698,12 +898,58 @@ cdef extern from "clBLAS.h":
         cl_uint numEventsInWaitList,
         const cl_event *eventWaitList,
         cl_event *events)
+    clblasStatus clblasCgemm(
+        clblasOrder order,
+        clblasTranspose transA,
+        clblasTranspose transB,
+        size_t M,
+        size_t N,
+        size_t K,
+        cl_float2 alpha,
+        const cl_mem A,
+        size_t offA,
+        size_t lda,
+        const cl_mem B,
+        size_t offB,
+        size_t ldb,
+        cl_float2 beta,
+        cl_mem C,
+        size_t offC,
+        size_t ldc,
+        cl_uint numCommandQueues,
+        cl_command_queue *commandQueues,
+        cl_uint numEventsInWaitList,
+        const cl_event *eventWaitList,
+        cl_event *events)
+    clblasStatus clblasZgemm(
+        clblasOrder order,
+        clblasTranspose transA,
+        clblasTranspose transB,
+        size_t M,
+        size_t N,
+        size_t K,
+        cl_double2 alpha,
+        const cl_mem A,
+        size_t offA,
+        size_t lda,
+        const cl_mem B,
+        size_t offB,
+        size_t ldb,
+        cl_double2 beta,
+        cl_mem C,
+        size_t offC,
+        size_t ldc,
+        cl_uint numCommandQueues,
+        cl_command_queue *commandQueues,
+        cl_uint numEventsInWaitList,
+        const cl_event *eventWaitList,
+        cl_event *events)
 
 
 def gemm(queue, A, B, C, transA=False, transB=False,
          float alpha=1.0, float beta=0.0):
     """C <- alpha * dot(A, B) + beta * C"""
-    dtype = check_dtype([A, B, C], ['float32', 'float64'])
+    dtype = check_dtype([A, B, C], ['float32', 'float64', 'complex64', 'complex128'])
     check_matrix(A, 'A')
     check_matrix(B, 'B')
     check_matrix(C, 'C')
@@ -748,6 +994,24 @@ def gemm(queue, A, B, C, transA=False, transB=False,
             clblasTrans if transB else clblasNoTrans,
             M, N, K, <cl_double>alpha, Adata, offA, lda, Bdata, offB, ldb,
             <cl_double>beta, Cdata, offC, ldc,
+            numCommandQueues, &commandQueue,
+            numEventsInWaitList, eventWaitList, &event)
+    elif dtype == np.dtype('complex64'):
+        err = clblasCgemm(
+            clblasRowMajor,
+            clblasTrans if transA else clblasNoTrans,
+            clblasTrans if transB else clblasNoTrans,
+            M, N, K, <cl_float2>cl_float2(x=alpha.real,y=alpha.imag), Adata, offA, lda, Bdata, offB, ldb,
+            <cl_float2>cl_float2(x=beta.real,y=beta.imag), Cdata, offC, ldc,
+            numCommandQueues, &commandQueue,
+            numEventsInWaitList, eventWaitList, &event)
+    elif dtype == np.dtype('complex128'):
+        err = clblasZgemm(
+            clblasRowMajor,
+            clblasTrans if transA else clblasNoTrans,
+            clblasTrans if transB else clblasNoTrans,
+            M, N, K, <cl_double2>cl_double2(x=alpha.real,y=alpha.imag), Adata, offA, lda, Bdata, offB, ldb,
+            <cl_double2>cl_double2(x=beta.real,y=beta.imag), Cdata, offC, ldc,
             numCommandQueues, &commandQueue,
             numEventsInWaitList, eventWaitList, &event)
     else:

--- a/pyopencl_blas/blas.pyx
+++ b/pyopencl_blas/blas.pyx
@@ -105,15 +105,15 @@ def swap(queue, x, y):
     check_shape_dim(y.shape, 0, N, 'y')
 
     cdef size_t element_size = dtype_size[dtype]
-    cdef cl_mem xdata = <cl_mem><int>x.base_data.int_ptr
+    cdef cl_mem xdata = <cl_mem><size_t>x.base_data.int_ptr
     cdef size_t offx = x.offset / element_size
     cdef int incx = x.strides[0] / element_size
-    cdef cl_mem ydata = <cl_mem><int>y.base_data.int_ptr
+    cdef cl_mem ydata = <cl_mem><size_t>y.base_data.int_ptr
     cdef size_t offy = y.offset / element_size
     cdef int incy = y.strides[0] / element_size
 
     cdef cl_uint numCommandQueues = 1
-    cdef cl_command_queue commandQueue = <cl_command_queue><int>queue.int_ptr
+    cdef cl_command_queue commandQueue = <cl_command_queue><size_t>queue.int_ptr
     cdef cl_uint numEventsInWaitList = 0
     cdef cl_event *eventWaitList = NULL
     cdef cl_event event = NULL
@@ -170,12 +170,12 @@ def scal(queue, alpha, x):
     cdef size_t N = x.shape[0]
 
     cdef size_t element_size = dtype_size[dtype]
-    cdef cl_mem xdata = <cl_mem><int>x.base_data.int_ptr
+    cdef cl_mem xdata = <cl_mem><size_t>x.base_data.int_ptr
     cdef size_t offx = x.offset / element_size
     cdef int incx = x.strides[0] / element_size
 
     cdef cl_uint numCommandQueues = 1
-    cdef cl_command_queue commandQueue = <cl_command_queue><int>queue.int_ptr
+    cdef cl_command_queue commandQueue = <cl_command_queue><size_t>queue.int_ptr
     cdef cl_uint numEventsInWaitList = 0
     cdef cl_event *eventWaitList = NULL
     cdef cl_event event = NULL
@@ -238,15 +238,15 @@ def copy(queue, x, y):
     check_shape_dim(y.shape, 0, N, 'y')
 
     cdef size_t element_size = dtype_size[dtype]
-    cdef cl_mem xdata = <cl_mem><int>x.base_data.int_ptr
+    cdef cl_mem xdata = <cl_mem><size_t>x.base_data.int_ptr
     cdef size_t offx = x.offset / element_size
     cdef int incx = x.strides[0] / element_size
-    cdef cl_mem ydata = <cl_mem><int>y.base_data.int_ptr
+    cdef cl_mem ydata = <cl_mem><size_t>y.base_data.int_ptr
     cdef size_t offy = y.offset / element_size
     cdef int incy = y.strides[0] / element_size
 
     cdef cl_uint numCommandQueues = 1
-    cdef cl_command_queue commandQueue = <cl_command_queue><int>queue.int_ptr
+    cdef cl_command_queue commandQueue = <cl_command_queue><size_t>queue.int_ptr
     cdef cl_uint numEventsInWaitList = 0
     cdef cl_event *eventWaitList = NULL
     cdef cl_event event = NULL
@@ -311,15 +311,15 @@ def axpy(queue, x, y, alpha=1.0):
     check_shape_dim(y.shape, 0, N, 'y')
 
     cdef size_t element_size = dtype_size[dtype]
-    cdef cl_mem xdata = <cl_mem><int>x.base_data.int_ptr
+    cdef cl_mem xdata = <cl_mem><size_t> x.base_data.int_ptr
     cdef size_t offx = x.offset / element_size
     cdef int incx = x.strides[0] / element_size
-    cdef cl_mem ydata = <cl_mem><int>y.base_data.int_ptr
+    cdef cl_mem ydata = <cl_mem><size_t>y.base_data.int_ptr
     cdef size_t offy = y.offset / element_size
     cdef int incy = y.strides[0] / element_size
 
     cdef cl_uint numCommandQueues = 1
-    cdef cl_command_queue commandQueue = <cl_command_queue><int>queue.int_ptr
+    cdef cl_command_queue commandQueue = <cl_command_queue><size_t>queue.int_ptr
     cdef cl_uint numEventsInWaitList = 0
     cdef cl_event *eventWaitList = NULL
     cdef cl_event event = NULL
@@ -387,17 +387,17 @@ def axpy(queue, x, y, alpha=1.0):
 #     check_shape_dim(y.shape, 0, N, 'y')
 
 #     cdef size_t element_size = dtype_size[dtype]
-#     cdef cl_mem ddata = <cl_mem><int>d.base_data.int_ptr
+#     cdef cl_mem ddata = <cl_mem><size_t>d.base_data.int_ptr
 #     cdef size_t offd = d.offset / element_size
-#     cdef cl_mem xdata = <cl_mem><int>x.base_data.int_ptr
+#     cdef cl_mem xdata = <cl_mem><size_t>x.base_data.int_ptr
 #     cdef size_t offx = x.offset / element_size
 #     cdef int incx = x.strides[0] / element_size
-#     cdef cl_mem ydata = <cl_mem><int>y.base_data.int_ptr
+#     cdef cl_mem ydata = <cl_mem><size_t>y.base_data.int_ptr
 #     cdef size_t offy = y.offset / element_size
 #     cdef int incy = y.strides[0] / element_size
 
 #     cdef cl_uint numCommandQueues = 1
-#     cdef cl_command_queue commandQueue = <cl_command_queue><int>queue.int_ptr
+#     cdef cl_command_queue commandQueue = <cl_command_queue><size_t>queue.int_ptr
 #     cdef cl_uint numEventsInWaitList = 0
 #     cdef cl_event *eventWaitList = NULL
 #     cdef cl_event event = NULL
@@ -457,14 +457,14 @@ def axpy(queue, x, y, alpha=1.0):
 #     cdef size_t N = x.shape[0]
 
 #     cdef size_t element_size = dtype_size[dtype]
-#     cdef cl_mem ddata = <cl_mem><int>d.base_data.int_ptr
+#     cdef cl_mem ddata = <cl_mem><size_t>d.base_data.int_ptr
 #     cdef size_t offd = d.offset / element_size
-#     cdef cl_mem xdata = <cl_mem><int>x.base_data.int_ptr
+#     cdef cl_mem xdata = <cl_mem><size_t>x.base_data.int_ptr
 #     cdef size_t offx = x.offset / element_size
 #     cdef int incx = x.strides[0] / element_size
 
 #     cdef cl_uint numCommandQueues = 1
-#     cdef cl_command_queue commandQueue = <cl_command_queue><int>queue.int_ptr
+#     cdef cl_command_queue commandQueue = <cl_command_queue><size_t>queue.int_ptr
 #     cdef cl_uint numEventsInWaitList = 0
 #     cdef cl_event *eventWaitList = NULL
 #     cdef cl_event event = NULL
@@ -524,14 +524,14 @@ def axpy(queue, x, y, alpha=1.0):
 #     cdef size_t N = x.shape[0]
 
 #     cdef size_t element_size = dtype_size[dtype]
-#     cdef cl_mem ddata = <cl_mem><int>d.base_data.int_ptr
+#     cdef cl_mem ddata = <cl_mem><size_t>d.base_data.int_ptr
 #     cdef size_t offd = d.offset / element_size
-#     cdef cl_mem xdata = <cl_mem><int>x.base_data.int_ptr
+#     cdef cl_mem xdata = <cl_mem><size_t>x.base_data.int_ptr
 #     cdef size_t offx = x.offset / element_size
 #     cdef int incx = x.strides[0] / element_size
 
 #     cdef cl_uint numCommandQueues = 1
-#     cdef cl_command_queue commandQueue = <cl_command_queue><int>queue.int_ptr
+#     cdef cl_command_queue commandQueue = <cl_command_queue><size_t>queue.int_ptr
 #     cdef cl_uint numEventsInWaitList = 0
 #     cdef cl_event *eventWaitList = NULL
 #     cdef cl_event event = NULL
@@ -613,18 +613,18 @@ def gemv(queue, A, x, y, bool transA=False, alpha=1.0, beta=0.0):
     check_shape_dim(y.shape, 0, (N if transA else M), 'y')
 
     cdef size_t element_size = dtype_size[dtype]
-    cdef cl_mem Adata = <cl_mem><int>A.base_data.int_ptr
+    cdef cl_mem Adata = <cl_mem><size_t>A.base_data.int_ptr
     cdef size_t offA = A.offset / element_size
     cdef size_t lda = A.strides[0] / element_size
-    cdef cl_mem xdata = <cl_mem><int>x.base_data.int_ptr
+    cdef cl_mem xdata = <cl_mem><size_t>x.base_data.int_ptr
     cdef size_t offx = x.offset / element_size
     cdef int incx = x.strides[0] / element_size
-    cdef cl_mem ydata = <cl_mem><int>y.base_data.int_ptr
+    cdef cl_mem ydata = <cl_mem><size_t>y.base_data.int_ptr
     cdef size_t offy = y.offset / element_size
     cdef int incy = y.strides[0] / element_size
 
     cdef cl_uint numCommandQueues = 1
-    cdef cl_command_queue commandQueue = <cl_command_queue><int>queue.int_ptr
+    cdef cl_command_queue commandQueue = <cl_command_queue><size_t>queue.int_ptr
     cdef cl_uint numEventsInWaitList = 0
     cdef cl_event *eventWaitList = NULL
     cdef cl_event event = NULL
@@ -716,18 +716,18 @@ def gemm(queue, A, B, C, transA=False, transB=False,
     check_shape_dim(C.shape, 1, N, 'C')
 
     cdef size_t element_size = dtype_size[dtype]
-    cdef cl_mem Adata = <cl_mem><int>A.base_data.int_ptr
+    cdef cl_mem Adata = <cl_mem><size_t>A.base_data.int_ptr
     cdef size_t offA = A.offset / element_size
     cdef size_t lda = A.strides[0] / element_size
-    cdef cl_mem Bdata = <cl_mem><int>B.base_data.int_ptr
+    cdef cl_mem Bdata = <cl_mem><size_t>B.base_data.int_ptr
     cdef size_t offB = B.offset / element_size
     cdef size_t ldb = B.strides[0] / element_size
-    cdef cl_mem Cdata = <cl_mem><int>C.base_data.int_ptr
+    cdef cl_mem Cdata = <cl_mem><size_t>C.base_data.int_ptr
     cdef size_t offC = C.offset / element_size
     cdef size_t ldc = C.strides[0] / element_size
 
     cdef cl_uint numCommandQueues = 1
-    cdef cl_command_queue commandQueue = <cl_command_queue><int>queue.int_ptr
+    cdef cl_command_queue commandQueue = <cl_command_queue><size_t>queue.int_ptr
     cdef cl_uint numEventsInWaitList = 0
     cdef cl_event *eventWaitList = NULL
     cdef cl_event event = NULL

--- a/pyopencl_blas/blas_base.pyx
+++ b/pyopencl_blas/blas_base.pyx
@@ -1,4 +1,5 @@
 cdef extern from "clBLAS.h":
+
     ctypedef enum clblasStatus:
         clblasSuccess
         clblasInvalidValue
@@ -34,6 +35,14 @@ cdef extern from "clBLAS.h":
     ctypedef float cl_float
     ctypedef double cl_double
     ctypedef unsigned int cl_uint
+
+    ctypedef struct cl_float2:
+        cl_float x
+        cl_float y
+
+    ctypedef struct cl_double2:
+        cl_double x
+        cl_double y
 
     struct _cl_mem:
         pass


### PR DESCRIPTION
larger pointer type
this fixes a runtime error when numpy arrays are allocated on a pointer value > 32bits
